### PR TITLE
Add first step for adding a script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This document serves as both the `README.md` for [this repository](https://githu
 
 ## How do I get my script on norns.community?
 
-After your pull request is merged to the [community catalog](https://github.com/monome/norns-community) it will *automatically appear* on [norns.community](https://norns.community). The website refreshes nightly at 00:00 UTC, on every merge to its `main` branch, or on demand by admins. [This GitHub action](https://github.com/monome-community/norns-community/actions/workflows/build.yml) has all the details.
+First, take a fork of the [community catalog](https://github.com/monome/norns-community), update `community.json` with your script's details, and make a pull request. After your pull request is accepted and merged it will *automatically appear* on [norns.community](https://norns.community). The website refreshes nightly at 00:00 UTC, on every merge to its `main` branch, or on demand by admins. [This GitHub action](https://github.com/monome-community/norns-community/actions/workflows/build.yml) has all the details.
 
 For script authors, this means:
 


### PR DESCRIPTION
This additional text adds (what was for me) crucial missing information. Currently the README talks about "your pull request" to add a new community script, but doesn't explain what or where that pull request should be. This fixes that.